### PR TITLE
[TASK] Othello Rules Engine（合法手/反転/パス/終了判定）

### DIFF
--- a/src/domain/rules.test.ts
+++ b/src/domain/rules.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createInitialBoard,
+  getLegalMoves,
+  applyMove,
+  canPass,
+  isGameFinished,
+  computeGameResult,
+  recomputeBoardFromMoves,
+} from './rules'
+import type { Board, Move } from './types'
+
+describe('Othello Rules Engine', () => {
+  describe('createInitialBoard', () => {
+    it('should create initial board with center pieces', () => {
+      const board = createInitialBoard()
+      // Center should be:
+      // [3][3] = WHITE, [3][4] = BLACK
+      // [4][3] = BLACK, [4][4] = WHITE
+      expect(board[3][3]).toBe('WHITE')
+      expect(board[3][4]).toBe('BLACK')
+      expect(board[4][3]).toBe('BLACK')
+      expect(board[4][4]).toBe('WHITE')
+      // Other cells should be null
+      expect(board[0][0]).toBeNull()
+      expect(board[7][7]).toBeNull()
+    })
+  })
+
+  describe('getLegalMoves', () => {
+    it('should return legal moves for initial board (BLACK)', () => {
+      const board = createInitialBoard()
+      const legalMoves = getLegalMoves(board, 'BLACK')
+      // Initial board: BLACK can play at (2,3), (3,2), (4,5), (5,4)
+      expect(legalMoves.length).toBeGreaterThan(0)
+      expect(legalMoves).toContainEqual({ row: 2, col: 3 })
+      expect(legalMoves).toContainEqual({ row: 3, col: 2 })
+      expect(legalMoves).toContainEqual({ row: 4, col: 5 })
+      expect(legalMoves).toContainEqual({ row: 5, col: 4 })
+    })
+
+    it('should return empty array when no legal moves', () => {
+      // Create a board where BLACK has no legal moves
+      const board: Board = [
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+      ]
+      const legalMoves = getLegalMoves(board, 'WHITE')
+      expect(legalMoves).toEqual([])
+    })
+  })
+
+  describe('applyMove', () => {
+    it('should apply valid move and flip pieces', () => {
+      const board = createInitialBoard()
+      const result = applyMove(board, 'BLACK', 2, 3)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        // After placing BLACK at (2,3), piece at (3,3) should flip to BLACK
+        expect(result.newState.board[2][3]).toBe('BLACK')
+        expect(result.newState.board[3][3]).toBe('BLACK')
+        expect(result.newState.nextTurnColor).toBe('WHITE')
+        expect(result.newState.isFinished).toBe(false)
+      }
+    })
+
+    it('should reject invalid move', () => {
+      const board = createInitialBoard()
+      const result = applyMove(board, 'BLACK', 0, 0)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeTruthy()
+      }
+    })
+
+    it('should reject move to occupied cell', () => {
+      const board = createInitialBoard()
+      const result = applyMove(board, 'BLACK', 3, 3)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('canPass', () => {
+    it('should return true when no legal moves', () => {
+      const board: Board = [
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+      ]
+      expect(canPass(board, 'WHITE')).toBe(true)
+    })
+
+    it('should return false when legal moves exist', () => {
+      const board = createInitialBoard()
+      expect(canPass(board, 'BLACK')).toBe(false)
+    })
+  })
+
+  describe('isGameFinished', () => {
+    it('should return false for initial board', () => {
+      const board = createInitialBoard()
+      expect(isGameFinished(board, 'BLACK', 'WHITE')).toBe(false)
+    })
+
+    it('should return true when board is full', () => {
+      const board: Board = [
+        [
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+        ],
+        [
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+        ],
+        [
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+        ],
+        [
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+        ],
+        [
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+          'WHITE',
+          'BLACK',
+        ],
+      ]
+      expect(isGameFinished(board, 'BLACK', 'WHITE')).toBe(true)
+    })
+
+    it('should return true when both players must pass', () => {
+      const board: Board = [
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+      ]
+      expect(isGameFinished(board, 'BLACK', 'WHITE')).toBe(true)
+    })
+  })
+
+  describe('computeGameResult', () => {
+    it('should count pieces correctly', () => {
+      const board: Board = [
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, 'WHITE', 'BLACK', null, null, null],
+        [null, null, null, 'BLACK', 'WHITE', null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+      const result = computeGameResult(board)
+      expect(result.blackCount).toBe(2)
+      expect(result.whiteCount).toBe(2)
+      expect(result.winner).toBeNull() // Draw
+    })
+
+    it('should determine winner correctly', () => {
+      const board: Board = [
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+        ],
+        [
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'BLACK',
+          'WHITE',
+          'WHITE',
+        ],
+      ]
+      const result = computeGameResult(board)
+      expect(result.blackCount).toBe(62)
+      expect(result.whiteCount).toBe(2)
+      expect(result.winner).toBe('BLACK')
+    })
+  })
+
+  describe('recomputeBoardFromMoves', () => {
+    it('should recompute board from empty moves (initial state)', () => {
+      const moves: Move[] = []
+      const board = recomputeBoardFromMoves(moves)
+      expect(board[3][3]).toBe('WHITE')
+      expect(board[3][4]).toBe('BLACK')
+      expect(board[4][3]).toBe('BLACK')
+      expect(board[4][4]).toBe('WHITE')
+    })
+
+    it('should recompute board from moves', () => {
+      const moves: Move[] = [
+        {
+          moveNumber: 1,
+          color: 'BLACK',
+          row: 2,
+          col: 3,
+          isPass: false,
+        },
+      ]
+      const board = recomputeBoardFromMoves(moves)
+      // After BLACK plays at (2,3), piece at (3,3) should flip to BLACK
+      expect(board[2][3]).toBe('BLACK')
+      expect(board[3][3]).toBe('BLACK')
+    })
+
+    it('should handle pass moves', () => {
+      const moves: Move[] = [
+        {
+          moveNumber: 1,
+          color: 'BLACK',
+          row: 2,
+          col: 3,
+          isPass: false,
+        },
+        {
+          moveNumber: 2,
+          color: 'WHITE',
+          row: null,
+          col: null,
+          isPass: true,
+        },
+      ]
+      const board = recomputeBoardFromMoves(moves)
+      // Board should reflect BLACK's move, WHITE's pass doesn't change board
+      expect(board[2][3]).toBe('BLACK')
+      expect(board[3][3]).toBe('BLACK')
+    })
+  })
+})

--- a/src/domain/rules.ts
+++ b/src/domain/rules.ts
@@ -1,0 +1,298 @@
+/**
+ * Othello Rules Engine
+ *
+ * Pure domain logic for Othello game rules:
+ * - Legal move detection
+ * - Move application (piece placement + flipping)
+ * - Pass detection
+ * - Game end detection
+ * - Board recomputation from moves
+ */
+
+import type {
+  Board,
+  PieceColor,
+  Position,
+  GameState,
+  ApplyMoveResult,
+  GameResult,
+  Move,
+  CellState,
+} from './types'
+
+/**
+ * Direction vectors (8 directions)
+ * Note: These are offsets, not board positions, so they can be negative
+ */
+interface Direction {
+  readonly row: number
+  readonly col: number
+}
+
+const DIRECTIONS: readonly Direction[] = [
+  { row: -1, col: -1 }, // top-left
+  { row: -1, col: 0 }, // top
+  { row: -1, col: 1 }, // top-right
+  { row: 0, col: -1 }, // left
+  { row: 0, col: 1 }, // right
+  { row: 1, col: -1 }, // bottom-left
+  { row: 1, col: 0 }, // bottom
+  { row: 1, col: 1 }, // bottom-right
+] as const
+
+/**
+ * Create initial board state (standard Othello starting position)
+ */
+export function createInitialBoard(): Board {
+  const board: CellState[][] = Array(8)
+    .fill(null)
+    .map(() => Array(8).fill(null))
+  // Center pieces
+  board[3][3] = 'WHITE'
+  board[3][4] = 'BLACK'
+  board[4][3] = 'BLACK'
+  board[4][4] = 'WHITE'
+  return board as Board
+}
+
+/**
+ * Check if position is within board bounds
+ */
+function isValidPosition(row: number, col: number): boolean {
+  return row >= 0 && row < 8 && col >= 0 && col < 8
+}
+
+/**
+ * Get opponent color
+ */
+function getOpponentColor(color: PieceColor): PieceColor {
+  return color === 'BLACK' ? 'WHITE' : 'BLACK'
+}
+
+/**
+ * Check if a move in a direction can flip pieces
+ * Returns positions of pieces that would be flipped, or empty array if invalid
+ */
+function checkDirection(
+  board: Board,
+  row: number,
+  col: number,
+  color: PieceColor,
+  direction: Direction
+): Position[] {
+  const opponentColor = getOpponentColor(color)
+  const flipped: Position[] = []
+  let currentRow = row + direction.row
+  let currentCol = col + direction.col
+
+  // Must start with opponent piece
+  if (
+    !isValidPosition(currentRow, currentCol) ||
+    board[currentRow][currentCol] !== opponentColor
+  ) {
+    return []
+  }
+
+  // Collect opponent pieces
+  while (
+    isValidPosition(currentRow, currentCol) &&
+    board[currentRow][currentCol] === opponentColor
+  ) {
+    flipped.push({
+      row: currentRow as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7,
+      col: currentCol as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7,
+    })
+    currentRow += direction.row
+    currentCol += direction.col
+  }
+
+  // Must end with own color
+  if (
+    isValidPosition(currentRow, currentCol) &&
+    board[currentRow][currentCol] === color
+  ) {
+    return flipped
+  }
+
+  return []
+}
+
+/**
+ * Check if a move is legal at given position
+ */
+function isLegalMove(
+  board: Board,
+  row: number,
+  col: number,
+  color: PieceColor
+): boolean {
+  // Cell must be empty
+  if (!isValidPosition(row, col) || board[row][col] !== null) {
+    return false
+  }
+
+  // Must flip at least one piece in at least one direction
+  for (const direction of DIRECTIONS) {
+    const flipped = checkDirection(board, row, col, color, direction)
+    if (flipped.length > 0) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Get all legal moves for a player
+ */
+export function getLegalMoves(board: Board, color: PieceColor): Position[] {
+  const legalMoves: Position[] = []
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      if (isLegalMove(board, row, col, color)) {
+        legalMoves.push({
+          row: row as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7,
+          col: col as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7,
+        })
+      }
+    }
+  }
+  return legalMoves
+}
+
+/**
+ * Apply a move to the board (place piece and flip opponent pieces)
+ * Returns new board state or error
+ */
+export function applyMove(
+  board: Board,
+  color: PieceColor,
+  row: number,
+  col: number
+): ApplyMoveResult {
+  // Validate position
+  if (!isValidPosition(row, col)) {
+    return { success: false, error: 'Invalid position' }
+  }
+
+  // Check if move is legal
+  if (!isLegalMove(board, row, col, color)) {
+    return { success: false, error: 'Illegal move' }
+  }
+
+  // Create new board
+  const newBoard: CellState[][] = board.map((rowArr) => [...rowArr])
+  newBoard[row][col] = color
+
+  // Flip pieces in all valid directions
+  for (const direction of DIRECTIONS) {
+    const flipped = checkDirection(board, row, col, color, direction)
+    for (const pos of flipped) {
+      newBoard[pos.row][pos.col] = color
+    }
+  }
+
+  const nextTurnColor = getOpponentColor(color)
+  const newState: GameState = {
+    board: newBoard as Board,
+    nextTurnColor,
+    isFinished: false,
+  }
+
+  return { success: true, newState }
+}
+
+/**
+ * Check if player can pass (no legal moves)
+ */
+export function canPass(board: Board, color: PieceColor): boolean {
+  return getLegalMoves(board, color).length === 0
+}
+
+/**
+ * Check if game is finished
+ * Game ends when:
+ * - Board is full, OR
+ * - Both players must pass consecutively
+ */
+export function isGameFinished(
+  board: Board,
+  currentTurnColor: PieceColor,
+  previousTurnColor: PieceColor
+): boolean {
+  // Check if board is full
+  let isEmpty = false
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      if (board[row][col] === null) {
+        isEmpty = true
+        break
+      }
+    }
+    if (isEmpty) break
+  }
+  if (!isEmpty) {
+    return true
+  }
+
+  // Check if both players must pass
+  const currentCanMove = getLegalMoves(board, currentTurnColor).length > 0
+  const previousCanMove = getLegalMoves(board, previousTurnColor).length > 0
+  return !currentCanMove && !previousCanMove
+}
+
+/**
+ * Compute game result (piece counts and winner)
+ */
+export function computeGameResult(board: Board): GameResult {
+  let blackCount = 0
+  let whiteCount = 0
+
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      const cell = board[row][col]
+      if (cell === 'BLACK') {
+        blackCount++
+      } else if (cell === 'WHITE') {
+        whiteCount++
+      }
+    }
+  }
+
+  let winner: PieceColor | null = null
+  if (blackCount > whiteCount) {
+    winner = 'BLACK'
+  } else if (whiteCount > blackCount) {
+    winner = 'WHITE'
+  }
+
+  return { blackCount, whiteCount, winner }
+}
+
+/**
+ * Recompute board state from moves sequence
+ * Starts from initial board and applies moves in order
+ */
+export function recomputeBoardFromMoves(moves: Move[]): Board {
+  let board = createInitialBoard()
+  let currentTurnColor: PieceColor = 'BLACK'
+
+  for (const move of moves) {
+    if (move.isPass) {
+      // Pass: just switch turn
+      currentTurnColor = getOpponentColor(currentTurnColor)
+    } else {
+      // Normal move: apply it
+      if (move.row !== null && move.col !== null) {
+        const result = applyMove(board, move.color, move.row, move.col)
+        if (result.success) {
+          board = result.newState.board
+          currentTurnColor = result.newState.nextTurnColor
+        }
+        // If move fails, we still continue (error handling at higher level)
+      }
+    }
+  }
+
+  return board
+}

--- a/src/domain/types.test.ts
+++ b/src/domain/types.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import type { Board, Move, GameState } from './types'
+
+describe('Domain Types', () => {
+  describe('Board type', () => {
+    it('should accept valid 8x8 board', () => {
+      const board: Board = [
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, 'BLACK', 'WHITE', null, null, null],
+        [null, null, null, 'WHITE', 'BLACK', null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+      expect(board.length).toBe(8)
+      expect(board[0].length).toBe(8)
+    })
+  })
+
+  describe('Move type', () => {
+    it('should represent normal move', () => {
+      const move: Move = {
+        moveNumber: 1,
+        color: 'BLACK',
+        row: 2,
+        col: 3,
+        isPass: false,
+      }
+      expect(move.isPass).toBe(false)
+      expect(move.row).toBe(2)
+      expect(move.col).toBe(3)
+    })
+
+    it('should represent pass move', () => {
+      const move: Move = {
+        moveNumber: 2,
+        color: 'WHITE',
+        row: null,
+        col: null,
+        isPass: true,
+      }
+      expect(move.isPass).toBe(true)
+      expect(move.row).toBeNull()
+      expect(move.col).toBeNull()
+    })
+  })
+
+  describe('GameState type', () => {
+    it('should represent game state', () => {
+      const board: Board = [
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, 'BLACK', 'WHITE', null, null, null],
+        [null, null, null, 'WHITE', 'BLACK', null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+        [null, null, null, null, null, null, null, null],
+      ]
+      const state: GameState = {
+        board,
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      }
+      expect(state.nextTurnColor).toBe('BLACK')
+      expect(state.isFinished).toBe(false)
+    })
+  })
+})

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Othello domain types
+ *
+ * Strict type definitions for board state, pieces, and game flow.
+ */
+
+/**
+ * Piece color: BLACK or WHITE
+ */
+export type PieceColor = 'BLACK' | 'WHITE'
+
+/**
+ * Cell state: empty, black piece, or white piece
+ */
+export type CellState = PieceColor | null
+
+/**
+ * Board coordinates (0-based, 0..7)
+ */
+export type Row = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+export type Col = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7
+
+/**
+ * Board position
+ */
+export interface Position {
+  readonly row: Row
+  readonly col: Col
+}
+
+/**
+ * 8x8 board state (row-major order)
+ * board[row][col] represents the cell at (row, col)
+ */
+export type Board = [
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+  [
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+    CellState,
+  ],
+]
+
+/**
+ * Move representation
+ * - Normal move: isPass=false, row/col are valid coordinates
+ * - Pass move: isPass=true, row/col are null
+ */
+export interface Move {
+  readonly moveNumber: number
+  readonly color: PieceColor
+  readonly row: Row | null
+  readonly col: Col | null
+  readonly isPass: boolean
+}
+
+/**
+ * Game state
+ */
+export interface GameState {
+  readonly board: Board
+  readonly nextTurnColor: PieceColor
+  readonly isFinished: boolean
+}
+
+/**
+ * Result of applying a move
+ */
+export type ApplyMoveResult =
+  | { readonly success: true; readonly newState: GameState }
+  | { readonly success: false; readonly error: string }
+
+/**
+ * Game end result
+ */
+export interface GameResult {
+  readonly blackCount: number
+  readonly whiteCount: number
+  readonly winner: PieceColor | null // null means draw
+}


### PR DESCRIPTION
## 対象 Issue
Closes #4

## TDD & Lint チェック
- [x] 新しいテストを追加し、そのテストが失敗すること（Red）を `make test` で確認した。
- [x] 実装を追加 / 修正し、同じテストが成功すること（Green）を `make test` で確認した。
- [x] `make lint` を実行し、すべてのエラーを解消した。

## Self-Walkthrough（要件と実装・テストの対応）

| Requirement (ID) | 実装・ロジック / テストとの対応 | 主なファイル / 関数 |
| :--- | :--- | :--- |
| R1: 8x8 盤面・石配置・手番（BLACK/WHITE）を厳密な型で表現 | `Board` 型を 8x8 のタプル型として定義し、`PieceColor` を `'BLACK' | 'WHITE'` として厳密に型付け。`CellState` は `PieceColor | null` として空マスを表現。テスト `src/domain/types.test.ts` で型の整合性を検証。 | `src/domain/types.ts` (`Board`, `PieceColor`, `CellState`, `GameState`) |
| R2: 合法手判定（置けるマス列挙） | `getLegalMoves()` 関数で全マスを走査し、`isLegalMove()` で各方向に反転可能な相手の石があるかチェック。テスト `src/domain/rules.test.ts` の `getLegalMoves` セクションで初期盤面と合法手なしのケースを検証。 | `src/domain/rules.ts` (`getLegalMoves`, `isLegalMove`, `checkDirection`) |
| R3: 着手適用（石配置 + 反転）、不正手は適用不可 | `applyMove()` 関数で合法手チェック後、新盤面を作成して石を配置し、全方向で反転処理を実行。`ApplyMoveResult` 型で成功/失敗を明示的に返却。テストで有効手・無効手・占有マスへの着手を検証。 | `src/domain/rules.ts` (`applyMove`, `ApplyMoveResult`) |
| R4: パス判定とパス手を move として表現 | `canPass()` 関数で合法手が0件かチェック。`Move` 型で `isPass=true` のとき `row/col` が `null` となることを型で保証。テストで合法手あり/なしのケースを検証。 | `src/domain/types.ts` (`Move`), `src/domain/rules.ts` (`canPass`) |
| R5: 終了判定と終了時の結果算出 | `isGameFinished()` で盤面が埋まったか、両者ともパス必須かを判定。`computeGameResult()` で全マスを走査して石数をカウントし、勝者を決定（同数の場合は `null`）。テストで盤面満杯・両者パス・勝敗判定を検証。 | `src/domain/rules.ts` (`isGameFinished`, `computeGameResult`, `GameResult`) |
| R6: moves から盤面を再計算できる | `recomputeBoardFromMoves()` 関数で初期盤面から開始し、moves を順次適用。パス手は手番のみ切り替え、通常手は `applyMove()` で適用。テストで空moves（初期状態）、通常手、パス手を含むケースを検証。 | `src/domain/rules.ts` (`recomputeBoardFromMoves`) |

## Decision Log（判断メモ・トレードオフ）

- **型安全性**: `Board` を 8x8 のタプル型として定義し、コンパイル時に盤面サイズを保証。`Row`/`Col` を 0-7 のリテラル型として定義し、範囲外アクセスを防止。
- **純粋関数設計**: UI依存・Storage依存を持たない純粋関数として実装し、テスト容易性と再利用性を確保。
- **方向ベクトル**: `DIRECTIONS` を `Position` 型ではなく `Direction` インターフェース（`row/col: number`）として定義し、負の値（-1）を許可。
- **エラーハンドリング**: `applyMove()` は `Result` 型パターンを使用し、例外ではなく明示的なエラー返却で不正手を扱う。
- **再計算ロジック**: `recomputeBoardFromMoves()` では不正な move が含まれていても処理を継続（エラーハンドリングは上位レイヤーに委譲）。これは Import/Restore 時のバリデーションと分離する設計。
