### PR TITLE
[TASK] OP_START_NEW_GAME: 新規ゲーム開始（確認含む）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -121,8 +121,10 @@ describe('App', () => {
     })
 
     // Click on a cell (legal move position)
-    const cells = screen.getAllByRole('button')
-    await user.click(cells[0])
+    // Get board cells specifically (not New Game button)
+    const board = screen.getByTestId('board')
+    const cells = board.querySelectorAll('button')
+    await user.click(cells[0] as HTMLElement)
 
     // placeStone should be called
     expect(gameState.placeStone).toHaveBeenCalledTimes(1)
@@ -154,12 +156,185 @@ describe('App', () => {
     })
 
     // Click on a cell (illegal move position)
-    const cells = screen.getAllByRole('button')
-    await user.click(cells[0])
+    // Get board cells specifically (not New Game button)
+    const board = screen.getByTestId('board')
+    const cells = board.querySelectorAll('button')
+    await user.click(cells[0] as HTMLElement)
 
     // placeStone should be called, but app should not crash
     expect(gameState.placeStone).toHaveBeenCalledTimes(1)
     // App should still be in playing state
     expect(screen.getByTestId('board')).toBeInTheDocument()
+  })
+
+  it('should show new game confirmation dialog when New Game button is clicked from PLAYING state', async () => {
+    const user = userEvent.setup()
+    const initialBoard = createInitialBoard()
+    vi.mocked(gameState.initializeGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: initialBoard,
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      },
+      moves: [],
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    })
+
+    // Click New Game button
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
+    await user.click(newGameButton)
+
+    // Should show confirmation dialog
+    expect(screen.getByText(/start new game/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/current game will be abandoned/i)
+    ).toBeInTheDocument()
+  })
+
+  it('should show new game confirmation dialog when New Game button is clicked from RESULT state', async () => {
+    const user = userEvent.setup()
+    const initialBoard = createInitialBoard()
+    vi.mocked(gameState.initializeGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: initialBoard,
+        nextTurnColor: 'BLACK',
+        isFinished: true,
+      },
+      moves: [],
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    })
+
+    // Click New Game button
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
+    await user.click(newGameButton)
+
+    // Should show confirmation dialog
+    expect(screen.getByText(/start new game/i)).toBeInTheDocument()
+  })
+
+  it('should start new game when Confirm is clicked in confirmation dialog', async () => {
+    const user = userEvent.setup()
+    const initialBoard = createInitialBoard()
+    vi.mocked(gameState.initializeGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: initialBoard,
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      },
+      moves: [],
+    })
+
+    // Mock startNewGame
+    vi.mocked(gameState.startNewGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: createInitialBoard(),
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      },
+      moves: [],
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    })
+
+    // Click New Game button
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
+    await user.click(newGameButton)
+
+    // Click Confirm button
+    const confirmButton = screen.getByRole('button', { name: /confirm/i })
+    await user.click(confirmButton)
+
+    // Should call startNewGame
+    expect(gameState.startNewGame).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return to previous state when Cancel is clicked in confirmation dialog', async () => {
+    const user = userEvent.setup()
+    const initialBoard = createInitialBoard()
+    vi.mocked(gameState.initializeGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: initialBoard,
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      },
+      moves: [],
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    })
+
+    // Click New Game button
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
+    await user.click(newGameButton)
+
+    // Click Cancel button
+    const cancelButton = screen.getByRole('button', { name: /cancel/i })
+    await user.click(cancelButton)
+
+    // Should return to PLAYING state
+    expect(screen.getByTestId('board')).toBeInTheDocument()
+    expect(screen.queryByText(/start new game/i)).not.toBeInTheDocument()
+  })
+
+  it('should show error when new game save fails', async () => {
+    const user = userEvent.setup()
+    const initialBoard = createInitialBoard()
+    vi.mocked(gameState.initializeGame).mockResolvedValue({
+      success: true,
+      gameState: {
+        board: initialBoard,
+        nextTurnColor: 'BLACK',
+        isFinished: false,
+      },
+      moves: [],
+    })
+
+    // Mock startNewGame to return error
+    vi.mocked(gameState.startNewGame).mockResolvedValue({
+      success: false,
+      error: 'Storage quota exceeded',
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    })
+
+    // Click New Game button
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
+    await user.click(newGameButton)
+
+    // Click Confirm button
+    const confirmButton = screen.getByRole('button', { name: /confirm/i })
+    await user.click(confirmButton)
+
+    // Should show error message
+    await waitFor(() => {
+      expect(screen.getByText(/error/i)).toBeInTheDocument()
+      expect(screen.getByText(/storage quota exceeded/i)).toBeInTheDocument()
+    })
   })
 })

--- a/src/app/gameState.test.ts
+++ b/src/app/gameState.test.ts
@@ -256,3 +256,47 @@ describe('placeStone', () => {
     expect(deviceLocalStorage.saveGameToDeviceLocal).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('startNewGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should create new game with empty moves and save to DeviceLocal', async () => {
+    const { startNewGame } = await import('./gameState')
+
+    vi.mocked(deviceLocalStorage.saveGameToDeviceLocal).mockReturnValue({
+      success: true,
+      data: undefined,
+    })
+
+    const result = await startNewGame()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.gameState).toBeTruthy()
+      expect(result.gameState.board).toEqual(createInitialBoard())
+      expect(result.gameState.nextTurnColor).toBe('BLACK')
+      expect(result.gameState.isFinished).toBe(false)
+      expect(result.moves).toEqual([])
+    }
+    expect(deviceLocalStorage.saveGameToDeviceLocal).toHaveBeenCalledTimes(1)
+    expect(deviceLocalStorage.saveGameToDeviceLocal).toHaveBeenCalledWith([])
+  })
+
+  it('should return error when DeviceLocal save fails', async () => {
+    const { startNewGame } = await import('./gameState')
+
+    vi.mocked(deviceLocalStorage.saveGameToDeviceLocal).mockReturnValue({
+      success: false,
+      error: 'Storage quota exceeded',
+    })
+
+    const result = await startNewGame()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Storage quota exceeded')
+    }
+  })
+})

--- a/src/app/gameState.ts
+++ b/src/app/gameState.ts
@@ -32,6 +32,12 @@ export type AppState =
       readonly gameState: GameState
       readonly moves: readonly Move[]
     }
+  | {
+      readonly type: 'NEW_GAME_CONFIRM'
+      readonly previousState: 'PLAYING' | 'RESULT'
+      readonly previousGameState: GameState
+      readonly previousMoves: readonly Move[]
+    }
 
 /**
  * Game initialization result
@@ -199,5 +205,36 @@ export async function placeStone(
     success: true,
     newGameState,
     newMoves,
+  }
+}
+
+/**
+ * Start new game (OP_START_NEW_GAME)
+ *
+ * R3: 新規ゲーム生成後、UIは STATE_PLAYING に遷移し、棋譜は空（moves=[]）相当から開始できる
+ * R4: DeviceLocal 保存失敗時はクラッシュせず、ユーザに分かる形でエラーを提示する
+ */
+export async function startNewGame(): Promise<GameInitializationResult> {
+  // Create new game with initial board
+  const initialBoard = createInitialBoard()
+  const gameState: GameState = {
+    board: initialBoard,
+    nextTurnColor: 'BLACK',
+    isFinished: false,
+  }
+
+  // R4: Save to DeviceLocal storage
+  const saveResult = saveGameToDeviceLocal([])
+  if (!saveResult.success) {
+    return {
+      success: false,
+      error: `Failed to save new game: ${saveResult.error}`,
+    }
+  }
+
+  return {
+    success: true,
+    gameState,
+    moves: [],
   }
 }


### PR DESCRIPTION
## 対象 Issue
Closes #7

## TDD & Lint チェック
- [x] 新しいテストを追加し、そのテストが失敗すること（Red）を `make test` で確認した。
- [x] 実装を追加 / 修正し、同じテストが成功すること（Green）を `make test` で確認した。
- [x] `make lint` を実行し、すべてのエラーを解消した。

## Self-Walkthrough（要件と実装・テストの対応）

| Requirement (ID) | 実装・ロジック / テストとの対応 | 主なファイル / 関数 |
| :--- | :--- | :--- |
| R1: `STATE_PLAYING` と `STATE_RESULT` の双方から「New Game」操作ができる。 | `PLAYING` 状態と `RESULT` 状態の両方に「New Game」ボタンを追加。テスト `src/App.test.tsx` の `should show new game confirmation dialog when New Game button is clicked from PLAYING state` と `should show new game confirmation dialog when New Game button is clicked from RESULT state` で検証。 | `src/App.tsx` の `handleNewGameClick` |
| R2: 確認ダイアログ（`STATE_NEW_GAME_CONFIRM` 相当）を出し、Confirm で新規ゲーム生成・保存、Cancel で元の状態に戻る。 | `AppState` 型に `NEW_GAME_CONFIRM` 状態を追加し、確認ダイアログを実装。Confirm で `startNewGame()` を呼び出し、Cancel で元の状態に戻る。テスト `src/App.test.tsx` の `should start new game when Confirm is clicked in confirmation dialog` と `should return to previous state when Cancel is clicked in confirmation dialog` で検証。 | `src/App.tsx` の `NEW_GAME_CONFIRM` 状態処理、`handleConfirm`、`handleCancel` |
| R3: 新規ゲーム生成後、UIは `STATE_PLAYING` に遷移し、棋譜は空（moves=[]）相当から開始できる。 | `startNewGame()` 関数で新規ゲームを生成し、空の moves 配列で保存。成功時に `STATE_PLAYING` に遷移。テスト `src/app/gameState.test.ts` の `should create new game with empty moves and save to DeviceLocal` と `src/App.test.tsx` の `should start new game when Confirm is clicked in confirmation dialog` で検証。 | `src/app/gameState.ts` の `startNewGame()` |
| R4: DeviceLocal 保存失敗時はクラッシュせず、ユーザに分かる形でエラーを提示する。 | `startNewGame()` で保存失敗時にエラーを返し、`App.tsx` で `STATE_ERROR` に遷移してエラーメッセージを表示。テスト `src/app/gameState.test.ts` の `should return error when DeviceLocal save fails` と `src/App.test.tsx` の `should show error when new game save fails` で検証。 | `src/app/gameState.ts` の `startNewGame()`、`src/App.tsx` の `handleConfirm` |

## Decision Log（判断メモ・トレードオフ）

- `NEW_GAME_CONFIRM` 状態に `previousState`、`previousGameState`、`previousMoves` を保持することで、Cancel 時に元の状態に正確に戻れるようにした。
- 確認ダイアログはシンプルな実装とし、将来的にモーダルコンポーネントとして分離する refactor Issue に回すことを検討。
- `startNewGame()` 関数は `initializeGame()` と同様の構造を持たせ、一貫性を保った。
