### PR TITLE
[DOCS] USE_CASES のエラー方針を実装に合わせて更新

### DIFF
--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -46,8 +46,8 @@ UMLの Fully Dressed Use Case を簡略化し、Domain / State / Operations と
 - Operations: [OP_OPEN_APP, OP_PLACE_STONE]
 
 - ErrorCases:
-  - 不正手（合法手でないマスのタップ）: 着手せず、UIでエラー/無効操作として扱う
-  - DeviceLocalへの保存失敗: エラー表示し、継続可否を明示する（少なくともクラッシュしない）
+  - 不正手（合法手でないマスのタップ）: `statusMessage` でエラーを表示し、状態は `STATE_PLAYING` のまま維持する（着手せず、元状態へ戻る）
+  - DeviceLocalへの保存失敗: `statusMessage` でエラーを表示し、状態は `STATE_PLAYING` のまま維持する（少なくともクラッシュしない）
 
 ---
 
@@ -70,9 +70,9 @@ UMLの Fully Dressed Use Case を簡略化し、Domain / State / Operations と
 - Operations: [OP_IMPORT_RECORD_FROM_FILE, OP_IMPORT_RECORD_FROM_CLIPBOARD]
 
 - ErrorCases:
-  - JSONがパースできない/スキーマ不正: 上書きせず、エラー表示して元の対局へ戻る
-  - クリップボード権限拒否: エラー表示して元の対局へ戻る
-  - DeviceLocalへの保存失敗: エラー表示し、復元結果が永続化されない可能性を明示する
+  - JSONがパースできない/スキーマ不正: `statusMessage` でエラーを表示し、状態は `STATE_PLAYING` のまま維持する（上書きせず、元の対局へ戻る）
+  - クリップボード権限拒否: `statusMessage` でエラーを表示し、状態は `STATE_PLAYING` のまま維持する（元の対局へ戻る）
+  - DeviceLocalへの保存失敗: `statusMessage` でエラーを表示し、状態は `STATE_PLAYING` のまま維持する（復元結果が永続化されない可能性を明示する）
 
 ---
 
@@ -97,8 +97,8 @@ UMLの Fully Dressed Use Case を簡略化し、Domain / State / Operations と
 - Operations: [OP_EXPORT_RECORD_TO_FILE, OP_EXPORT_RECORD_TO_CLIPBOARD]
 
 - ErrorCases:
-  - クリップボード権限拒否: エラー表示し、ファイル出力など代替手段を案内する
-  - ダウンロード失敗: エラー表示し、再試行可能にする
+  - クリップボード権限拒否: `statusMessage` でエラーを表示し、元の状態（`STATE_PLAYING` または `STATE_RESULT`）へ戻る（ファイル出力など代替手段を案内する）
+  - ダウンロード失敗: `statusMessage` でエラーを表示し、元の状態（`STATE_PLAYING` または `STATE_RESULT`）へ戻る（再試行可能にする）
 
 ---
 
@@ -122,7 +122,7 @@ UMLの Fully Dressed Use Case を簡略化し、Domain / State / Operations と
 - Operations: [OP_START_NEW_GAME]
 
 - ErrorCases:
-  - DeviceLocalへの保存失敗: エラー表示し、復元できない可能性を明示する
+  - DeviceLocalへの保存失敗: `statusMessage` でエラーを表示し、状態は `STATE_NEW_GAME_CONFIRM` のまま維持する（復元できない可能性を明示する）
 
 <!--
 Record Format (Draft, custom JSON):


### PR DESCRIPTION
## 対象 Issue
Closes #31

## TDD & Lint チェック
- [x] ドキュメント更新のため、テストの追加は不要（既存テストはすべて通過）。
- [x] `make lint` を実行し、すべてのエラーを解消した。

## Self-Walkthrough（要件と実装・テストの対応）

| Requirement (ID) | 実装・ロジック / テストとの対応 | 主なファイル / 関数 |
| :--- | :--- | :--- |
| R1: UC-1/2/3/4 の ErrorCases が実装方針と矛盾しない（import/export/new game/invalid move/save fail）。 | `docs/USE_CASES.md` の各ユースケースの ErrorCases を、実装方針（recoverable error は `statusMessage` 表示＋元状態へ戻る）に合わせて更新。UC-1: 不正手・保存失敗は `statusMessage` でエラー表示し、状態は `STATE_PLAYING` のまま維持。UC-2: JSONパース失敗・クリップボード権限拒否・保存失敗は `statusMessage` でエラー表示し、状態は `STATE_PLAYING` のまま維持。UC-3: クリップボード権限拒否・ダウンロード失敗は `statusMessage` でエラー表示し、元の状態（`STATE_PLAYING` または `STATE_RESULT`）へ戻る。UC-4: 保存失敗は `statusMessage` でエラー表示し、状態は `STATE_NEW_GAME_CONFIRM` のまま維持。 | `docs/USE_CASES.md` |
| R2: `docs/INTERACTION_FLOW.md`（Issue #26）と整合する。 | `INTERACTION_FLOW.md` の statusMessage 方針（エラー発生時、`STATE_ERROR` への遷移は行わず、`statusMessage` でエラーを表示し、元の状態を維持する）と整合していることを確認。更新後の `USE_CASES.md` の ErrorCases は、すべてこの方針に従っている。 | `docs/USE_CASES.md`, `docs/INTERACTION_FLOW.md` |
| R3: 更新後にユースケースの State 遷移の前提が破綻しない。 | 各ユースケースの States 項目を確認し、エラー時の状態遷移が前提と矛盾しないことを確認。UC-1: `[STATE_LOADING -> STATE_PLAYING -> STATE_RESULT]` - エラー時は `STATE_PLAYING` のまま → OK。UC-2: `[STATE_PLAYING -> STATE_IMPORT_CONFIRM -> STATE_IMPORTING -> STATE_PLAYING]` - エラー時は `STATE_PLAYING` のまま → OK。UC-3: `[STATE_PLAYING -> STATE_EXPORTING -> STATE_PLAYING]` または `[STATE_RESULT -> STATE_EXPORTING -> STATE_RESULT]` - エラー時は元の状態へ戻る → OK。UC-4: `[STATE_PLAYING -> STATE_NEW_GAME_CONFIRM -> STATE_PLAYING]` - エラー時は `STATE_NEW_GAME_CONFIRM` のまま → OK。 | `docs/USE_CASES.md` |

## Decision Log（判断メモ・トレードオフ）

- **エラーハンドリング方針の統一**: すべての recoverable error を `statusMessage` で表示し、元の状態を維持する方針に統一することで、実装とドキュメントの整合性を確保。
- **状態遷移の整合性**: エラー時の状態遷移が各ユースケースの States 項目と矛盾しないことを確認し、State 遷移の前提が破綻しないようにした。

