### PR TITLE
[DOCS] REQUIREMENT の整合性確認と更新（実装反映）

### DIFF
--- a/docs/REQUIREMENT.md
+++ b/docs/REQUIREMENT.md
@@ -113,7 +113,24 @@ ER 図だけでは表現しづらいルールや補足がある場合に記述�
 
 - Interaction State Diagram: see `INTERACTION_FLOW.md`  
 
-### 3.2 Public Operations / APIs
+### 3.2 Error Handling Policy (statusMessage / STATE_ERROR)
+
+<!--
+エラー処理の方針を明確にする。
+statusMessage と STATE_ERROR の使い分けを定義する。
+-->
+
+- **statusMessage**:  
+  - 各状態で表示可能な一時的なメッセージ（エラー/情報）を表す。  
+  - エラー発生時、STATE_ERROR への遷移は行わず、statusMessage でエラーを表示し、元の状態を維持する。  
+  - 例: 不正手の着手試行、インポートバリデーション失敗、ストレージ保存失敗など。  
+  - アクセシビリティ対応: `aria-live="polite"` でスクリーンリーダーに通知される。  
+- **STATE_ERROR**:  
+  - アプリ起動時の初期化失敗など、回復不可能なエラーのみに限定される。  
+  - 例: DeviceLocal からのゲーム復元失敗、新規ゲーム生成失敗など。  
+  - ユーザは「再試行」ボタンで STATE_LOADING に戻り、初期化を再実行できる。
+
+### 3.3 Public Operations / APIs
 
 <!--
 クライアント(人間・他システム・外部アプリ等)から見える操作/インターフェースを列挙する。
@@ -132,7 +149,7 @@ Web の場合は HTTP パス、CLI の場合はコマンド、ゲーム/組み�
 | OP_EXPORT_RECORD_TO_FILE | UI / Export File | 現在対局の棋譜（独自JSON）をファイルとして書き出す |
 | OP_EXPORT_RECORD_TO_CLIPBOARD | UI / Copy JSON | 現在対局の棋譜（独自JSON）をクリップボードへコピーする |
 
-### 3.3 Use Cases
+### 3.4 Use Cases
 
 <!--
 ユースケースの詳細仕様は USE_CASES.md に記述する。


### PR DESCRIPTION
Closes #32

## Self-Walkthrough

### Requirements 対応表

| Requirement | 対応内容 | 実装/ドキュメント |
|------------|---------|------------------|
| R1: 主要な状態/操作/エラー方針（statusMessage / STATE_ERROR の扱い）が現状と矛盾しない | `docs/REQUIREMENT.md` に新規セクション「3.2 Error Handling Policy (statusMessage / STATE_ERROR)」を追加。`INTERACTION_FLOW.md` に記載されている方針を `REQUIREMENT.md` に明示的に記載することで、実装との整合性を確保。 | `docs/REQUIREMENT.md` 3.2 セクション |
| R2: `docs/USE_CASES.md` / `docs/INTERACTION_FLOW.md` との参照関係が破綻しない | セクション番号を調整（3.2 → 3.3, 3.3 → 3.4）。参照関係を確認し、整合性を維持。 | `docs/REQUIREMENT.md` セクション番号調整 |
| R3: Security/Storage 方針（段階的バリデーション、トランザクショナル上書き等）が実装と矛盾しない | 実装を確認し、`REQUIREMENT.md` の記載（4.3 Non-Functional Requirements）が実装と一致していることを確認。変更不要。 | `docs/REQUIREMENT.md` 4.3 セクション（変更なし） |

### 変更内容

- `docs/REQUIREMENT.md` に「3.2 Error Handling Policy (statusMessage / STATE_ERROR)」セクションを追加
  - statusMessage の扱い（一時的なエラー/情報メッセージ、元の状態を維持）
  - STATE_ERROR の扱い（回復不可能なエラーのみ、初期化失敗時など）
  - アクセシビリティ対応（aria-live="polite"）の記載
- セクション番号を調整（3.2 → 3.3, 3.3 → 3.4）

### 検証

- `make test`: すべてのテストが通過（132 tests passed）
- `make lint`: Lint エラーなし
- 実装コードとの整合性を確認：
  - `src/App.tsx`: statusMessage の使用、STATE_ERROR の扱いがドキュメントと一致
  - `src/app/gameState.ts`: エラー処理がドキュメントの方針と一致
  - `src/storage/recordFormat.ts`, `src/storage/deviceLocalStorage.ts`: 段階的バリデーションとトランザクショナル上書きが実装されていることを確認

